### PR TITLE
Make similar setup than in NodeNumbering.jl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,16 @@ julia:
     - release
     - nightly
     - 0.5.2
+before_script:
+    - julia --color=yes -e 'Pkg.clone(pwd())'
+    - julia --color=yes -e 'Pkg.add("Coverage")'
+    - julia --color=yes -e 'Pkg.add("Documenter")'
+    - julia --color=yes -e 'Pkg.add("Lint")'
+script:
+    - julia --color=yes -e 'Pkg.build("AbaqusReader")'
+    - julia --color=yes -e 'Pkg.test("AbaqusReader", coverage=true)'
 after_success:
-    - julia -e 'Pkg.add("Coverage")'
-    - julia -e 'cd(Pkg.dir("AbaqusReader")); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-    - julia -e 'Pkg.add("Documenter")'
-    - julia -e 'cd(Pkg.dir("AbaqusReader")); using Documenter; include(joinpath("docs", "make.jl"))'
+    - julia --color=yes -e 'cd(Pkg.dir("AbaqusReader", "test")); include("run_lint.jl")'
+    - julia --color=yes -e 'cd(Pkg.dir("AbaqusReader", "docs")); include("make.jl")'
+    - julia --color=yes -e 'cd(Pkg.dir("AbaqusReader")); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+    - julia --color=yes -e 'cd(Pkg.dir("AbaqusReader", "docs")); include("deploy.jl")'

--- a/docs/deploy.jl
+++ b/docs/deploy.jl
@@ -4,7 +4,6 @@
 using Documenter
 using AbaqusReader
 
-makedocs(
-    modules = [AbaqusReader],
-    checkdocs = :all,
-    strict = true)
+deploydocs(
+    deps = Deps.pip("mkdocs", "python-markdown-math"),
+    repo = "github.com/JuliaFEM/AbaqusReader.jl.git")

--- a/test/run_lint.jl
+++ b/test/run_lint.jl
@@ -1,0 +1,17 @@
+# This file is a part of project JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/NodeNumbering.jl/blob/master/LICENSE
+
+using Lint
+using Base.Test
+
+results = lintpkg("AbaqusReader")
+if !isempty(results)
+    info("Lint.jl is a tool that uses static analysis to assist in the development process by detecting common bugs and potential issues.")
+    info("For this package, Lint.jl report is following:")
+    display(results)
+    info("For more information, see https://lintjl.readthedocs.io/en/stable/")
+    warn("Package syntax test has failed.")
+    @test isempty(results)
+else
+    info("Lint.jl: syntax check pass.")
+end


### PR DESCRIPTION
Use `Lint.jl` to check syntax and separate documentation build process
using `Documenter.jl` to `make.jl` and `deploy.jl`, where doctests are
in `make.jl` and they are causing error of build if something is failing.

Here we have these extra steps in `after_success` part in `.travis.yml`
because old code needs quite lot of tuning that it pass all the
requirements.