### PR TITLE
Add new function: abaqus_read_mesh

### DIFF
--- a/src/AbaqusReader.jl
+++ b/src/AbaqusReader.jl
@@ -10,4 +10,6 @@ include("keyword_register.jl")
 include("parse_model.jl")
 include("create_surface_elements.jl")
 
+export abaqus_read_mesh, abaqus_read_model
+
 end

--- a/src/parse_mesh.jl
+++ b/src/parse_mesh.jl
@@ -258,3 +258,14 @@ function parse_abaqus(fid::IOStream)
     end
     return model
 end
+
+"""
+    abaqus_read_mesh(fn::String)
+
+Read ABAQUS mesh from file `fn`. Returns a dict with elements, nodes,
+element sets, node sets and other topologically imporant things, but
+not the actual model with boundary conditions, load steps and so on.
+"""
+function abaqus_read_mesh(fn::String)
+    return open(parse_abaqus, fn)
+end

--- a/test/test_parse_mesh.jl
+++ b/test/test_parse_mesh.jl
@@ -65,7 +65,7 @@ end
 
 @testset "parse abaqus .inp created using hypermesh" begin
     fn = joinpath(datadir, "hypermesh_model.inp")
-    mesh = open(parse_abaqus, fn)
+    mesh = abaqus_read_mesh(fn)
     @test length(mesh["nodes"]) == 2
 end
 

--- a/test/test_parse_mesh.jl
+++ b/test/test_parse_mesh.jl
@@ -4,7 +4,7 @@
 using Base.Test
 
 using AbaqusReader: element_has_type, element_has_nodes, parse_abaqus,
-                    parse_section
+                    parse_section, abaqus_read_mesh
 
 datadir = first(splitext(basename(@__FILE__)))
 


### PR DESCRIPTION
Add new function `abaqus_read_mesh` which takes filename as input and returns the mesh in Dict. So now we have two functions with same syntax: `abaqus_read_mesh` for mesh reading and `abaqus_read_model` to read whole model using more logic.