### PR TITLE
Implement new function abaqus_download

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,6 +12,7 @@ end
 ## Exported functions
 
 ```@docs
+AbaqusReader.abaqus_download
 AbaqusReader.abaqus_read_mesh
 AbaqusReader.abaqus_read_model
 AbaqusReader.create_surface_elements

--- a/src/AbaqusReader.jl
+++ b/src/AbaqusReader.jl
@@ -9,7 +9,9 @@ include("parse_mesh.jl")
 include("keyword_register.jl")
 include("parse_model.jl")
 include("create_surface_elements.jl")
+include("abaqus_download.jl")
 
 export abaqus_read_mesh, abaqus_read_model, create_surface_elements
+export abaqus_download
 
 end

--- a/src/abaqus_download.jl
+++ b/src/abaqus_download.jl
@@ -1,0 +1,47 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/AbaqusReader.jl/blob/master/LICENSE
+
+"""
+    abaqus_download(model_name; dryrun=false)
+
+Download ABAQUS model from Internet. `model_name` is the name of the input
+file.
+
+Given some model name from documentation, e.g., `et22sfse`, download that
+file to local file system. This function uses environment variables to
+determine the download url and place of storage.
+
+In order to use this function, one must set environment variable
+`ABAQUS_DOWNLOAD_URL`, which determines a location where to download. For
+example, if the path to model is `https://domain.com/v6.14/books/eif/et22sfse.inp`,
+`ABAQUS_DOWNLOAD_URL` will be the basename of that path, i.e.,
+`https://domain.com/v6.14/books/eif`.
+
+By default, the model will be downloaded to current directory. If that is not
+desired, one can set another environment variable `ABAQUS_DOWNLOAD_DIR`, and
+in that case the file will be downloaded to that directory.
+
+Function call will return full path to downloaded file or nothing, if download
+is failing because of missing environment variable `ABAQUS_DOWNLOAD_DIR`.
+"""
+function abaqus_download(model_name; dryrun=false)
+    path = ""
+    if haskey(ENV, "ABAQUS_DOWNLOAD_DIR")
+        path = ENV["ABAQUS_DOWNLOAD_DIR"]
+    end
+    fn = joinpath(path, model_name)
+    if isfile(fn)  # already downloaded
+        return fn
+    end
+    if !haskey(ENV, "ABAQUS_DOWNLOAD_URL")
+        info("ABAQUS input file $fn not found and `ABAQUS_DOWNLOAD_URL` not ",
+             "set, unable to download file. To enable automatic model ",
+             "downloading, set url to models to environment variable
+             `ABAQUS_DOWNLOAD_URL`")
+        return nothing
+    end
+    url = joinpath(ENV["ABAQUS_DOWNLOAD_URL"], model_name)
+    info("Downloading model $model_name to $fn")
+    dryrun || download(url, fn)
+    return fn
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,4 +8,5 @@ using Base.Test
     include("test_parse_mesh.jl")
     include("test_parse_model.jl")
     include("test_create_surface_elements.jl")
+    include("test_download.jl")
 end

--- a/test/test_download.jl
+++ b/test/test_download.jl
@@ -1,0 +1,23 @@
+# This file is a part of JuliaFEM.
+# License is MIT: see https://github.com/JuliaFEM/AbaqusReader.jl/blob/master/LICENSE
+
+using AbaqusReader
+using Base.Test
+
+@testset "test abaqus_download" begin
+    delete!(ENV, "ABAQUS_DOWNLOAD_URL")
+    delete!(ENV, "ABAQUS_DOWNLOAD_DIR")
+    fn = tempname()
+    touch(fn)
+    model_name = basename(fn)
+    ENV["ABAQUS_DOWNLOAD_DIR"] = dirname(fn)
+    println("fn = ", fn)
+    println("isfile(fn) = ", isfile(fn))
+    println("model_name = ", model_name)
+    println("ABAQUS_DOWNLOAD_DIR = ", ENV["ABAQUS_DOWNLOAD_DIR"])
+    @test abaqus_download(model_name) == fn
+    rm(fn)
+    @test abaqus_download(model_name) == nothing
+    ENV["ABAQUS_DOWNLOAD_URL"] = "https://models.com"
+    @test abaqus_download(model_name; dryrun=true) == fn
+end


### PR DESCRIPTION
A function can be used to download test models from the internet. In order to
use the function, one must set environment variable `ABAQUS_DOWNLOAD_URL`. See also PR #28.