### PR TITLE
Fix test for abaqus_download

### DIFF
--- a/src/abaqus_download.jl
+++ b/src/abaqus_download.jl
@@ -25,10 +25,7 @@ Function call will return full path to downloaded file or nothing, if download
 is failing because of missing environment variable `ABAQUS_DOWNLOAD_DIR`.
 """
 function abaqus_download(model_name; dryrun=false)
-    path = ""
-    if haskey(ENV, "ABAQUS_DOWNLOAD_DIR")
-        path = ENV["ABAQUS_DOWNLOAD_DIR"]
-    end
+    path = get(ENV, "ABAQUS_DOWNLOAD_DIR", ".")
     fn = joinpath(path, model_name)
     if isfile(fn)  # already downloaded
         return fn

--- a/test/test_download.jl
+++ b/test/test_download.jl
@@ -5,19 +5,17 @@ using AbaqusReader
 using Base.Test
 
 @testset "test abaqus_download" begin
+    original_ENV = copy(ENV)
     delete!(ENV, "ABAQUS_DOWNLOAD_URL")
     delete!(ENV, "ABAQUS_DOWNLOAD_DIR")
     fn = tempname()
     touch(fn)
     model_name = basename(fn)
     ENV["ABAQUS_DOWNLOAD_DIR"] = dirname(fn)
-    println("fn = ", fn)
-    println("isfile(fn) = ", isfile(fn))
-    println("model_name = ", model_name)
-    println("ABAQUS_DOWNLOAD_DIR = ", ENV["ABAQUS_DOWNLOAD_DIR"])
     @test abaqus_download(model_name) == fn
-    rm(fn)
+    isfile(fn) && rm(fn)
     @test abaqus_download(model_name) == nothing
     ENV["ABAQUS_DOWNLOAD_URL"] = "https://models.com"
     @test abaqus_download(model_name; dryrun=true) == fn
+    merge!(ENV, original_ENV)
 end


### PR DESCRIPTION
Return environment variables to the original state after finish test.