### PR TITLE
Replace abstract Integer with concrete Int type

### DIFF
--- a/src/create_surface_elements.jl
+++ b/src/create_surface_elements.jl
@@ -30,7 +30,7 @@ const element_mapping = Dict(
 element. E.g. for Tet4 we have 4 sides S1..S4 and boundary element is of type Tri3.
 """
 function create_surface_element(element_type::Symbol, element_side::Symbol,
-    element_connectivity::Vector{Int64})
+    element_connectivity::Vector{Int})
 
     if !haskey(element_mapping, element_type)
         error("Unable to find surface element for element of type ",
@@ -59,7 +59,7 @@ function create_surface_elements(mesh::Dict, surface_name::String)
     surface = mesh["surface_sets"][surface_name]
     elements = mesh["elements"]
     eltypes = mesh["element_types"]
-    result = Tuple{Symbol, Vector{Integer}}[]
+    result = Tuple{Symbol, Vector{Int}}[]
     for (elid, side) in surface
         surface_element = create_surface_element(eltypes[elid], side, elements[elid])
         push!(result, surface_element)

--- a/src/parse_mesh.jl
+++ b/src/parse_mesh.jl
@@ -94,7 +94,7 @@ end
 """
 function parse_section(model, lines, ::Symbol, idx_start, idx_end, ::Type{Val{:NODE}})
     nnodes = 0
-    ids = Integer[]
+    ids = Int[]
     definition = lines[idx_start]
     for line in lines[idx_start + 1: idx_end]
         if !(empty_or_comment_line(line))
@@ -141,7 +141,7 @@ Reads element ids and their connectivity nodes from input lines.
 If elset definition exists, also adds the set to model.
 """
 function parse_section(model, lines, ::Symbol, idx_start, idx_end, ::Type{Val{:ELEMENT}})
-    ids = Integer[]
+    ids = Int[]
     definition = lines[idx_start]
     regexp = r"TYPE=([\w\-\_]+)"i
     m = match(regexp, definition)
@@ -177,7 +177,7 @@ end
 """
 function parse_section(model, lines, key, idx_start, idx_end, ::Union{Type{Val{:NSET}},
         Type{Val{:ELSET}}})
-    data = Integer[]
+    data = Int[]
     set_regex_string = Dict(:NSET  => r"NSET=([\w\-\_]+)"i,
                             :ELSET => r"ELSET=([\w\-\_]+)"i)
     selected_set = key == :NSET ? "node_sets" : "element_sets"
@@ -194,7 +194,7 @@ function parse_section(model, lines, key, idx_start, idx_end, ::Union{Type{Val{:
     else
         for line in lines[idx_start + 1: idx_end]
             if !(empty_or_comment_line(line))
-                set_ids = parse_numbers(line, Int)
+                set_ids = parse_numbers(line, Int)::Vector{Int}
                 push!(data, set_ids...)
             end
         end
@@ -205,7 +205,7 @@ end
 """Parse SURFACE keyword
 """
 function parse_section(model, lines, ::Symbol, idx_start, idx_end, ::Type{Val{:SURFACE}})
-    data = Vector{Tuple{Int64, Symbol}}()
+    data = Vector{Tuple{Int, Symbol}}()
     definition = lines[idx_start]
 
     has_set_def = parse_definition(definition)
@@ -228,7 +228,7 @@ end
 """Find lines, which contain keywords, for example "*NODE"
 """
 function find_keywords(lines)
-    indexes = Integer[]
+    indexes = Int[]
     for (idx, line) in enumerate(lines)
         if startswith(line, "*") && !startswith(line, "**")
             push!(indexes, idx)
@@ -244,12 +244,12 @@ all the available keywords.
 """
 function parse_abaqus(fid::IOStream)
     model = Dict{String, Dict}()
-    model["nodes"] = Dict{Int64, Vector{Float64}}()
-    model["node_sets"] = Dict{String, Vector{Int64}}()
-    model["elements"] = Dict{Integer, Vector{Integer}}()
-    model["element_types"] = Dict{Integer, Symbol}()
-    model["element_sets"] = Dict{String, Vector{Int64}}()
-    model["surface_sets"] = Dict{String, Vector{Tuple{Int64, Symbol}}}()
+    model["nodes"] = Dict{Int, Vector{Float64}}()
+    model["node_sets"] = Dict{String, Vector{Int}}()
+    model["elements"] = Dict{Int, Vector{Int}}()
+    model["element_types"] = Dict{Int, Symbol}()
+    model["element_sets"] = Dict{String, Vector{Int}}()
+    model["surface_sets"] = Dict{String, Vector{Tuple{Int, Symbol}}}()
     model["surface_types"] = Dict{String, Symbol}()
     keyword_sym::Symbol = :none
 

--- a/src/parse_model.jl
+++ b/src/parse_model.jl
@@ -15,10 +15,10 @@ abstract type AbstractOutputRequest end
 
 mutable struct Mesh
     nodes :: Dict{Int, Vector{Float64}}
-    node_sets :: Dict{String, Vector{Integer}}
+    node_sets :: Dict{String, Vector{Int}}
     elements :: Dict{Int, Vector{Int}}
     element_types :: Dict{Int, Symbol}
-    element_sets :: Dict{String, Vector{Integer}}
+    element_sets :: Dict{String, Vector{Int}}
     surface_sets :: Dict{String, Vector{Tuple{Int, Symbol}}}
     surface_types :: Dict{String, Symbol}
 end

--- a/test/test_parse_mesh.jl
+++ b/test/test_parse_mesh.jl
@@ -25,11 +25,11 @@ end
     3,         4,       176
     """
     data = split(data, "\n")
-    model = Dict{AbstractString, Any}()
-    model["node_sets"] = Dict{AbstractString, Vector{Int}}()
-    model["elements"] = Dict{Integer, Vector{Integer}}()
-    model["element_sets"] = Dict{AbstractString, Vector{Int}}()
-    model["element_types"] = Dict{Integer, Symbol}()
+    model = Dict{String, Any}()
+    model["node_sets"] = Dict{String, Vector{Int}}()
+    model["elements"] = Dict{Int, Vector{Int}}()
+    model["element_sets"] = Dict{String, Vector{Int}}()
+    model["element_types"] = Dict{Int, Symbol}()
     parse_section(model, data, :ELEMENT, 1, 5, Val{:ELEMENT})
     @test length(model["elements"]) == 2
     @test model["element_sets"]["BEAM"] == [1, 2]
@@ -98,7 +98,7 @@ end
 
 @testset "parse ELSET" begin
     lines = ["*ELSET, ELSET=TEST1", "1"]
-    mesh = Dict("element_sets" => Dict{String, Vector{Int64}}())
+    mesh = Dict("element_sets" => Dict{String, Vector{Int}}())
     parse_section(mesh, lines, :ELSET, 1, 2, Val{:ELSET})
     @test mesh["element_sets"]["TEST1"] == [1]
 end


### PR DESCRIPTION
Resolves https://github.com/JuliaFEM/AbaqusReader.jl/issues/50

Also change AbstractString to String in model dictionary.

This may improve performance, see:
https://docs.julialang.org/en/v1/manual/performance-tips/#Avoid-containers-with-abstract-type-parameters-1

Benchmarks
==========

It seems there is a very small improvement in performance,
but allocations and memory have been reduced.

```
julia> import Logging; Logging.disable_logging(Logging.Error)
julia> using AbaqusReader, BenchmarkTools
julia> @benchmark abaqus_read_mesh("tet4.inp")
```

Before:
```
BenchmarkTools.Trial:
  memory estimate:  980.23 KiB
  allocs estimate:  17939
  --------------
  minimum time:     1.050 ms (0.00% GC)
  median time:      1.140 ms (0.00% GC)
  mean time:        1.223 ms (6.28% GC)
  maximum time:     5.272 ms (77.52% GC)
  --------------
  samples:          4082
  evals/sample:     1
```

After:
```
BenchmarkTools.Trial:
  memory estimate:  916.25 KiB
  allocs estimate:  15570
  --------------
  minimum time:     1.004 ms (0.00% GC)
  median time:      1.094 ms (0.00% GC)
  mean time:        1.174 ms (6.58% GC)
  maximum time:     5.905 ms (78.07% GC)
  --------------
  samples:          4251
  evals/sample:     1
```