### PR TITLE
Make parse_numbers function type stable

### DIFF
--- a/src/parse_mesh.jl
+++ b/src/parse_mesh.jl
@@ -73,7 +73,7 @@ end
 
 """Parse all the numbers from string
 """
-function parse_numbers(line, type_)
+function parse_numbers(line, type_::Type{T})::Vector{T} where T
     regexp = r"[0-9]+"
     matches = collect((m.match for m = eachmatch(regexp, line)))
     map(x-> Base.parse(type_, x), matches)


### PR DESCRIPTION
The `parse_numbers` function should return a vector of the same type
that is given as the `type_` argument (previously it returned `Vector{Any}`).

Fixes the following error in tests:
```
parse nodes from abaqus .inp file to Mesh (NX export): Error During Test at AbaqusReader.jl/test/test_parse_mesh.jl:59
  Got exception outside of a @test
  TypeError: in typeassert, expected Array{Int64,1}, got Array{Any,1}
  Stacktrace:
   [1] parse_section(::Dict{String,Dict}, ::Array{String,1}, ::Symbol, ::Int64, ::Int64, ::Type{Val{:ELSET}}) at AbaqusReader.jl/src/parse_mesh.jl:197
   [2] parse_abaqus(::IOStream) at AbaqusReader.jl/src/parse_mesh.jl:268
```