### PR TITLE
Added two element types that are among those generated by gmsh. 

### DIFF
--- a/src/parse_mesh.jl
+++ b/src/parse_mesh.jl
@@ -7,6 +7,9 @@ import Base.parse
 element_has_nodes(::Type{Val{:C3D4}}) = 4
 element_has_type( ::Type{Val{:C3D4}}) = :Tet4
 
+element_has_nodes(::Type{Val{:C3D6}}) = 6
+element_has_type( ::Type{Val{:C3D6}}) = :Wedge6
+
 element_has_nodes(::Type{Val{:C3D4H}}) = 4
 element_has_type( ::Type{Val{:C3D4H}}) = :Tet4
 
@@ -26,6 +29,9 @@ element_has_nodes(::Type{Val{:C3D20E}}) = 20
 
 element_has_nodes(::Type{Val{:S3}}) = 3
 element_has_type( ::Type{Val{:S3}}) = :Tri3
+
+element_has_nodes(::Type{Val{:CPS3}}) = 3
+element_has_type( ::Type{Val{:CPS3}}) = :CPS3
 
 element_has_nodes(::Type{Val{:STRI65}}) = 6
 element_has_type(::Type{Val{:STRI65}}) = :Tri6


### PR DESCRIPTION
The element types are
- C3D6, a 6 nodes element that produces the key Wedge6
- CPS3, a 3 nodes element that produces the key CPS3 (Tri3 alerady exists)

I think they are convenient as you do not have to change the element names  of the elements in the input file before loading the mesh with AbaquReader.jl, which what I have been doing so far.

Everything seems to work as expected.